### PR TITLE
[raylib] Simplify custom modules options

### DIFF
--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -50,7 +50,7 @@ class RaylibConan(ConanFile):
         return Version(self.version) >= "4.2.0"
 
     @property
-    def _support_rpand_generator(self):
+    def _support_rprand_generator(self):
         return Version(self.version) >= "5.0"
 
     @property
@@ -67,7 +67,7 @@ class RaylibConan(ConanFile):
             del self.options.opengl_version
         if not self._support_custom_modules:
             del self.options.module_raudio
-        if not self._support_rpand_generator:
+        if not self._support_rprand_generator:
             del self.options.rprand_generator
         if not self._support_frame_control:
             del self.options.custom_frame_control
@@ -126,7 +126,7 @@ class RaylibConan(ConanFile):
             # this makes it include the headers rcamera.h, rgesture.h and rprand.h
             tc.variables["SUPPORT_CAMERA_SYSTEM"]    = self.options.camera_system
             tc.variables["SUPPORT_GESTURES_SYSTEM"]  = self.options.gestures_system
-            if self._support_rpand_generator:
+            if self._support_rprand_generator:
                 tc.variables["SUPPORT_RPRAND_GENERATOR"] = self.options.rprand_generator
 
         # Due to a specific logic of cmakedeps_macros.cmake used by CMakeDeps to try to locate shared libs on Windows
@@ -162,7 +162,7 @@ class RaylibConan(ConanFile):
             copy(self, pattern="*camera.h", dst=include_path, src=os.path.join(self.source_folder, "src"))
         if self.options.get_safe("gestures_system", True):
             copy(self, pattern="*gestures.h", dst=include_path, src=os.path.join(self.source_folder, "src"))
-        if self._support_rpand_generator and self.options.get_safe("rprand_generator", True):
+        if self._support_rprand_generator and self.options.get_safe("rprand_generator", True):
             copy(self, pattern="rprand.h", dst=include_path, src=os.path.join(self.source_folder, "src", "external"))
 
     def _create_cmake_module_alias_targets(self, module_file, targets):

--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -159,9 +159,9 @@ class RaylibConan(ConanFile):
         # INFO: Custom modules are enabled by default but need to copy the headers manually
         include_path = os.path.join(self.package_folder, "include")
         if self.options.get_safe("camera_system", True):
-            copy(self, pattern="rcamera.h", dst=include_path, src=os.path.join(self.source_folder, "src"))
+            copy(self, pattern="*camera.h", dst=include_path, src=os.path.join(self.source_folder, "src"))
         if self.options.get_safe("gestures_system", True):
-            copy(self, pattern="rgestures.h", dst=include_path, src=os.path.join(self.source_folder, "src"))
+            copy(self, pattern="*gestures.h", dst=include_path, src=os.path.join(self.source_folder, "src"))
         if self._support_rpand_generator and self.options.get_safe("rprand_generator", True):
             copy(self, pattern="rprand.h", dst=include_path, src=os.path.join(self.source_folder, "src", "external"))
 

--- a/recipes/raylib/all/test_package/conanfile.py
+++ b/recipes/raylib/all/test_package/conanfile.py
@@ -16,9 +16,6 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def generate(self):
-        copy(self, pattern="rcamera.h", src=self.dependencies["raylib"].cpp_info.resdirs[0], dst=os.path.join(self.build_folder, "raylib_stuff"))
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/raylib/all/test_package/test_package.c
+++ b/recipes/raylib/all/test_package/test_package.c
@@ -1,7 +1,5 @@
 #include "raylib.h"
 
-#include "raylib_stuff/rcamera.h"
-
 #include <stdio.h>
 
 int main(void) {
@@ -10,9 +8,6 @@ int main(void) {
   if (CheckCollisionSpheres(center, r, center, r)) {
     printf("unit sphere collides with itself!\n");
   }
-  Camera3D cam;
-  cam.fovy = 0;
-  printf("%f\n", cam.fovy);
 
   return 0;
 }


### PR DESCRIPTION
Hello!

Doing a new fresh review over the PR https://github.com/conan-io/conan-center-index/pull/24585, I concluded that there is not need for adding those modules headers in res folder, because raudio.h is installed in include folder and it's optional as well.

Plus, some features are only available after specific versions:

- rprand generator: https://github.com/raysan5/raylib/commit/fc7dcff4a72e3ce9ea970ad4e03cfabed026fbad
- custom frame control: https://github.com/raysan5/raylib/commit/5b4aaf4eb1b848d023b3bac0ce7a8e34faab9ba1
- module raudio: https://github.com/raysan5/raylib/commit/e637ad9d2a62fdcc2d4917de63defef5f8fb0591

When available and enabled, they should be copied to the package folder.

On version 3.5.0, camera system's header uses the file `camera.h`. Same for gestures.

Do not need to validate it in test package as it's an optional feature. Only local build logs in the PR are needed to.

Full Build logs: https://gist.github.com/uilianries/d70e816158a8e9e9cbd7a8a6ce6aebee

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
